### PR TITLE
Fix missing skip properties to schema validation

### DIFF
--- a/src/modules/jobsGenerator/04-validateTemplateHead.ts
+++ b/src/modules/jobsGenerator/04-validateTemplateHead.ts
@@ -7,6 +7,8 @@ export function validateTemplateHead(templateHead: TemplateHead) {
   if (validationResult.error != null) {
     throw new ValidateTemplateHeadError(ValidateTemplateHeadErrorCode.INVALID_TEMPLATE_HEAD_SCHEMA)
   }
+
+  return validationResult
 }
 
 export enum ValidateTemplateHeadErrorCode {

--- a/src/modules/jobsGenerator/index.ts
+++ b/src/modules/jobsGenerator/index.ts
@@ -1,4 +1,4 @@
-import { GeneratorArgs, GeneratorConfig, Job } from '~/types'
+import { GeneratorArgs, GeneratorConfig, Job, TemplateHead } from '~/types'
 import { discoverTemplates } from './00-discoverTemplates'
 import { parseTemplate } from './01-parseTemplate'
 import { renderTemplateHead } from './02-renderTemplateHead'
@@ -26,23 +26,24 @@ export async function getGeneratorJobs(
       let renderedTemplateHead = renderTemplateHead(templateHead, args)
       let parsedTemplateHead = parseTemplateHead(renderedTemplateHead)
       // TODO: Show validation errors
-      // @ts-ignore
       let templateHeadValidationResult = validateTemplateHead(parsedTemplateHead)
+      let validatedTemplateHead = templateHeadValidationResult.value as TemplateHead
       if (generatorConfig.hooks?.afterParseTemplateHead != null)
-        parsedTemplateHead =
-          (await generatorConfig.hooks?.afterParseTemplateHead(parsedTemplateHead, args)) ?? parsedTemplateHead
+        validatedTemplateHead =
+          (await generatorConfig.hooks?.afterParseTemplateHead(validatedTemplateHead, args)) ?? validatedTemplateHead
 
       if (generatorConfig.hooks?.beforeParseTemplateBody != null)
         templateBody =
-          (await generatorConfig.hooks?.beforeParseTemplateBody(parsedTemplateHead, templateBody, args)) ?? templateBody
-      let renderedTemplateBody = renderTemplateBody(parsedTemplateHead, templateBody, args)
+          (await generatorConfig.hooks?.beforeParseTemplateBody(validatedTemplateHead, templateBody, args)) ??
+          templateBody
+      let renderedTemplateBody = renderTemplateBody(validatedTemplateHead, templateBody, args)
       if (generatorConfig.hooks?.afterParseTemplateBody != null)
         renderedTemplateBody =
-          (await generatorConfig.hooks?.afterParseTemplateBody(parsedTemplateHead, renderedTemplateBody, args)) ??
+          (await generatorConfig.hooks?.afterParseTemplateBody(validatedTemplateHead, renderedTemplateBody, args)) ??
           renderedTemplateBody
 
       return {
-        templateHead: parsedTemplateHead,
+        templateHead: validatedTemplateHead,
         templateBody: renderedTemplateBody,
       }
     })

--- a/src/schemas/templateHeadSchema/skipSchema.ts
+++ b/src/schemas/templateHeadSchema/skipSchema.ts
@@ -27,6 +27,10 @@ export function getSkipSchema(modes: TemplateSkipMode[]) {
   if (modes.includes(TemplateSkipMode.REGEX)) {
     schema = schema.when(joi.object({ mode: TemplateSkipMode.REGEX }).unknown(), {
       then: joi.object({
+        skipOn: joi.string().valid('match', 'noMatch').default('match').messages({
+          'string.base': 'Must be one of the following string values: match, noMatch',
+          'any.only': 'Must be one of the following string values: match, noMatch',
+        }),
         pattern: joi.string().required().messages({
           'string.base': 'Must be a regex pattern',
           'any.required': 'This property is required',
@@ -44,7 +48,11 @@ export function getSkipSchema(modes: TemplateSkipMode[]) {
   if (modes.includes(TemplateSkipMode.SEARCH)) {
     schema = schema.when(joi.object({ mode: TemplateSkipMode.SEARCH }).unknown(), {
       then: joi.object({
-        text: joi.string().required().messages({
+        skipOn: joi.string().valid('match', 'noMatch').default('match').messages({
+          'string.base': 'Must be one of the following string values: match, noMatch',
+          'any.only': 'Must be one of the following string values: match, noMatch',
+        }),
+        search: joi.string().required().messages({
           'string.base': 'Must a string',
           'any.required': 'This property is required',
         }),


### PR DESCRIPTION
The schema was missing the "skipOn" property.

This also fixes the wrongly named "text" property on a "search" skip.

Lastly, the generator uses the schema validation result value for the template header now, so it will actually use the defaults set with joi.