### PR TITLE
Fix inject template event destinationNotFound event action "create"

### DIFF
--- a/src/modules/jobsGenerator/subModules/eventDestinationNotFound.ts
+++ b/src/modules/jobsGenerator/subModules/eventDestinationNotFound.ts
@@ -7,7 +7,7 @@ export async function getEventDestinationNotFoundResolutionType(
   destinationPath: string
 ) {
   if (templateHead.on?.destinationNotFound?.action === 'create') {
-    return JobType.OVERRIDE
+    return JobType.CREATE
   } else if (templateHead.on?.destinationNotFound?.action === 'skip') {
     return JobType.SKIP
   } else if (templateHead.on?.destinationNotFound?.action === 'exit') {


### PR DESCRIPTION
When the job type returned by the event handler was was `JobType.OVERRIDE` the job execution would fail on missing the file. This has been changes to `JobType.CREATE` and now the action is handled as intended.