### PR TITLE
Fix missing args in generator config `promptOptions` function

### DIFF
--- a/src/bin/Generator_Run.ts
+++ b/src/bin/Generator_Run.ts
@@ -39,7 +39,7 @@ export async function Generator_Run() {
           const answer = await prompt({
             name: argConfig.name,
             ...(typeof argConfig.promptOptions === 'function'
-              ? argConfig.promptOptions(argv)
+              ? argConfig.promptOptions(args)
               : argConfig.promptOptions),
           }) // TODO: Handle error
           args[argConfig.name] = answer[argConfig.name]


### PR DESCRIPTION
The generator config files args can take a function for `prompOptions` returning the options to pass to enquirer. This function takes the `args` defined so far, but only the args acquired from the CLI was being passed.