### PR TITLE
Add better, more consistent and streamlined prompt options to generator config

### DIFF
--- a/src/bin/Generator_Run.ts
+++ b/src/bin/Generator_Run.ts
@@ -1,74 +1,53 @@
 import { prompt } from 'enquirer'
-import { camelCase } from 'change-case'
+import { camelCase, paramCase } from 'change-case'
 import { discoverGenerators } from '~/utils/discover'
 import { getGeneratorJobs } from '~/modules/jobsGenerator'
 import { createHistoryEntry } from '~/modules/history'
 import { executeJobQueue } from '~/modules/executeJobQueue'
-import { GeneratorArgs } from '~/types'
+import { parseGeneratorArgs } from '~/modules/generatorArgsParser/generatorArgsParser'
+import { GeneratorArgs, GeneratorConfig } from '~/types'
 
 const argv = require('yargs-parser')(process.argv.slice(2))
 
 export async function Generator_Run() {
-  const [generatorDirPath, generatorConfig] = await (async () => {
-    const modelNameArg = argv._[0]
-    if (modelNameArg != null) {
-      const paramGenerator = await findGenerator(modelNameArg)
+  // Chose template
+  const templateNameArg = argv._[0]
+  if (templateNameArg != null) {
+    const paramGenerator = await findGenerator(templateNameArg)
 
-      if (paramGenerator != null) return paramGenerator
-      else console.error('Error: Supplied generator was not found, please select one from the list.')
-    }
-    const selectedGeneratorName = await selectGenerator()
-    return (await findGenerator(selectedGeneratorName))!
-  })()
+    if (paramGenerator != null) return paramGenerator
+    else console.error('Error: Supplied generator was not found, please select one from the list.')
+  }
+  const selectedGeneratorName = await selectGenerator()
+  const [generatorDirPath, generatorConfig] = (await findGenerator(selectedGeneratorName))!
   delete argv._
 
-  // Hook
+  // Start
   if (generatorConfig.hooks?.onStart != null) generatorConfig.hooks?.onStart()
 
-  // Hook
+  // Parse args
   if (generatorConfig.hooks?.beforeArgsParser != null) await generatorConfig.hooks.beforeArgsParser(argv)
-
-  let args: GeneratorArgs = {}
-  if (Array.isArray(generatorConfig.args)) {
-    for (const argConfig of generatorConfig.args) {
-      if (
-        argv[argConfig.name] == null ||
-        (typeof argConfig.validate === 'function' && argConfig.validate(argv[argConfig.name], argv))
-      ) {
-        if (argConfig.promptOptions != null) {
-          const answer = await prompt({
-            name: argConfig.name,
-            ...(typeof argConfig.promptOptions === 'function'
-              ? argConfig.promptOptions(args)
-              : argConfig.promptOptions),
-          }) // TODO: Handle error
-          args[argConfig.name] = answer[argConfig.name]
-        }
-        // TODO: Error
-      } else {
-        args[argConfig.name] = argv[argConfig.name]
-      }
-    }
+  let args: GeneratorArgs
+  try {
+    args = await parseGeneratorArgs(generatorConfig, argv)
+  } catch (e) {
+    console.log(e)
+    process.exit(0)
   }
-
-  // Hook
+  const command = getFullCommand(generatorConfig, args)
+  console.log('Running command:', command, '\n')
   if (generatorConfig.hooks?.afterArgsParser != null) args = (await generatorConfig.hooks.afterArgsParser(args)) ?? args
 
-  const command =
-    'kig' +
-    ' ' +
-    generatorConfig.name +
-    ' ' +
-    Object.entries(args)
-      .map(([k, v]) => (typeof v === 'string' && v.includes(' ') ? `--${k} "${v}"` : `--${k} ${v}`))
-      .join(' ')
-
+  // Read the templates and generate the job queue
   const jobs = await getGeneratorJobs(args, generatorDirPath, generatorConfig)
 
-  createHistoryEntry(jobs, command)
+  // Create history entry if the history is enabled
+  await createHistoryEntry(jobs, command)
+
+  // Process the previously created job queue
   executeJobQueue(jobs)
 
-  // Hook
+  // End
   if (generatorConfig.hooks?.onEnd != null) await generatorConfig.hooks?.onEnd()
 }
 
@@ -88,4 +67,18 @@ async function selectGenerator() {
 async function findGenerator(generatorName: string) {
   const availableGenerators = await discoverGenerators()
   return availableGenerators.find(([, gConfig]) => camelCase(gConfig.name) === camelCase(generatorName))
+}
+
+function getFullCommand(generatorConfig: GeneratorConfig, args: GeneratorArgs) {
+  const commandGeneratorName = generatorConfig.name.includes(' ') ? `"${generatorConfig.name}"` : generatorConfig.name
+  const commandArgs = Object.entries(args)
+    .map(([k, v]) => {
+      const argKey = paramCase(k)
+      const argValue = typeof v === 'string' && v.includes(' ') ? `"${v}"` : v
+      return `--${argKey} ${argValue}`
+    })
+    .join(' ')
+  const command = `kig ${commandGeneratorName} ${commandArgs}`
+
+  return command
 }

--- a/src/modules/generatorArgsParser/generatorArgsParser.ts
+++ b/src/modules/generatorArgsParser/generatorArgsParser.ts
@@ -1,0 +1,99 @@
+import { prompt } from 'enquirer'
+import { GeneratorArgConfigEntry, GeneratorArgs, GeneratorArgValue, GeneratorConfig } from '~/types'
+
+export async function parseGeneratorArgs(generatorConfig: GeneratorConfig, argv: { [key: string]: string | boolean }) {
+  let args = {}
+  if (Array.isArray(generatorConfig.args)) {
+    for (let argConfig of generatorConfig.args) {
+      const arg = argv[argConfig.name]
+      if (typeof argConfig === 'function') argConfig = await argConfig(args)
+
+      args[argConfig.name] = parseGeneratorArg(argConfig, arg, args)
+    }
+  }
+
+  return args
+}
+
+async function parseGeneratorArg(argConfig: GeneratorArgConfigEntry, arg: GeneratorArgValue, args: GeneratorArgs) {
+  if (arg == null || (typeof argConfig.validate === 'function' && argConfig.validate(arg, args))) {
+    if (argConfig.prompt != null) {
+      try {
+        let answer: GeneratorArgValue
+        if (typeof argConfig.prompt === 'function') {
+          answer = await argConfig.prompt(args)
+        } else {
+          let promptOptions: Parameters<typeof prompt>[0]
+          switch (argConfig.prompt.type) {
+            case 'confirm':
+              promptOptions = {
+                type: 'confirm',
+                name: argConfig.name,
+                message: argConfig.prompt.message,
+              }
+              break
+
+            case 'input':
+              promptOptions = {
+                type: 'input',
+                name: argConfig.name,
+                message: argConfig.prompt.message,
+              }
+              break
+
+            case 'select':
+              promptOptions = {
+                type: 'autocomplete',
+                name: argConfig.name,
+                message: argConfig.prompt.message,
+                choices: argConfig.prompt.choices,
+              }
+              break
+
+            case 'multi-select':
+              promptOptions = {
+                type: 'autocomplete',
+                name: argConfig.name,
+                muliple: true,
+                message: argConfig.prompt.message,
+                choices: argConfig.prompt.choices,
+              }
+              break
+          }
+
+          const promptResult = await prompt(promptOptions)
+          answer = promptResult[argConfig.name]
+        }
+
+        return parseGeneratorArg(argConfig, answer, args)
+      } catch (e) {
+        throw new ParseGeneratorArgsPromptFailedError(argConfig.name)
+      }
+    }
+    throw new ParseGeneratorArgsMissingArgError(argConfig.name)
+  } else {
+    return arg
+  }
+}
+
+export class ParseGeneratorArgsPromptFailedError extends Error {
+  constructor(argName: string) {
+    super()
+
+    this.argName = argName
+    this.message = `The supplied value for arg: ${argName} is invalid, exiting...`
+  }
+
+  argName: string
+}
+
+export class ParseGeneratorArgsMissingArgError extends Error {
+  constructor(argName: string) {
+    super()
+
+    this.argName = argName
+    this.message = `No value supplied for arg: ${argName}, exiting...`
+  }
+
+  argName: string
+}

--- a/src/modules/generatorArgsParser/index.ts
+++ b/src/modules/generatorArgsParser/index.ts
@@ -1,0 +1,1 @@
+export * from './generatorArgsParser'

--- a/src/schemas/generatorConfigSchema/generatorConfigPromptOptionsSchema.ts
+++ b/src/schemas/generatorConfigSchema/generatorConfigPromptOptionsSchema.ts
@@ -1,0 +1,37 @@
+import joi from 'joi'
+
+export function getGeneratorConfigPromptOptionsSchema() {
+  const promptTypes = ['confirm', 'input', 'select', 'multi-select']
+  let schema = joi.object({
+    type: joi
+      .string()
+      .valid(...promptTypes)
+      .required()
+      .messages({
+        'string.base': `Unknown type. Use one of the following: ${promptTypes.join(', ')}`,
+        'any.only': `Unknown type. Use one of the following: ${promptTypes.join(', ')}`,
+        'any.required': 'This property is required',
+      }),
+    message: joi.string().required().messages({
+      'string.base': `Must be a descriptive message to be shown to the user`,
+      'any.required': 'This property is required',
+    }),
+  })
+
+  schema = schema.when(joi.object({ type: 'select' }).unknown(), {
+    then: joi.object({
+      choices: joi.array().required().messages({
+        'any.required': 'This property is required',
+      }),
+    }),
+  })
+  schema = schema.when(joi.object({ type: 'multi-select' }).unknown(), {
+    then: joi.object({
+      choices: joi.array().required().messages({
+        'any.required': 'This property is required',
+      }),
+    }),
+  })
+
+  return schema
+}

--- a/src/schemas/generatorConfigSchema/generatorConfigSchema.ts
+++ b/src/schemas/generatorConfigSchema/generatorConfigSchema.ts
@@ -1,13 +1,16 @@
 import joi from 'joi'
+import { getGeneratorConfigPromptOptionsSchema } from './generatorConfigPromptOptionsSchema'
 
 export const generatorConfigSchema = joi.object({
   name: joi.string().required(),
   description: joi.string(),
   args: joi.array().items(
+    joi.function(),
     joi.object({
       name: joi.string().required(),
       description: joi.string(),
-      promptOptions: joi.alternatives().try(joi.function(), joi.object()),
+      default: joi.alternatives().try(joi.string(), joi.boolean()),
+      prompt: joi.alternatives().try(getGeneratorConfigPromptOptionsSchema(), joi.function()),
       validate: joi.function(),
     })
   ),

--- a/src/types/GeneratorArg.ts
+++ b/src/types/GeneratorArg.ts
@@ -1,9 +1,43 @@
-import { prompt } from 'enquirer'
+import { PromptOptions } from './GeneratorPromptOptions'
 
 export type GeneratorArgValue = string | boolean
 export type GeneratorArgs = { [key: string]: GeneratorArgValue }
-type PromptOptions = Omit<Parameters<typeof prompt>[0], 'name'>
-type PromptOptionsFunction = (args: GeneratorArgs) => PromptOptions
+
+type CustomPromptFunction = (args: GeneratorArgs) => GeneratorArgValue | Promise<GeneratorArgValue>
+type ArgValidationFunction = (
+  arg: GeneratorArgValue,
+  args: GeneratorArgs
+) => boolean | ArgValidationObject | Promise<boolean | ArgValidationObject>
+
+/**
+ * Function that returns the arg config entry.
+ * @param args The arguments that has been determined so far.
+ */
+export type GeneratorArgConfigEntryFunction = (
+  args: GeneratorArgs
+) => GeneratorArgConfigEntry | Promise<GeneratorArgConfigEntry>
+export interface GeneratorArgConfigEntry {
+  /**
+   * The arg name, that you'll use to refer to the arg in the templates.
+   */
+  name: string
+  /**
+   * A short description to show in the commands help page.
+   */
+  description?: string
+  /**
+   * Default value for the argument, to be used if the argument is missing.
+   */
+  default?: GeneratorArgValue
+  /**
+   * Options for showing a prompt if the arg is invalid or missing.
+   */
+  prompt?: PromptOptions | CustomPromptFunction
+  /**
+   * A function to validate the supplied value of the arg.
+   */
+  validate?: ArgValidationFunction
+}
 
 export interface ArgValidationObject {
   /**
@@ -14,27 +48,4 @@ export interface ArgValidationObject {
    * If the arg is invalid, this reason will be supplied to the user.
    */
   reason?: string
-}
-
-export interface GeneratorArgConfigEntry {
-  /**
-   * The arg name, that you'll use to refer to the arg in the templates. When used in the CLI, it will be converted to dash-case.
-   */
-  name: string
-  /**
-   * A short description to show in the commands help page.
-   */
-  description?: string
-  /**
-   * Default value for tge argument, to be used if the argument is missing.
-   */
-  default?: GeneratorArgValue
-  /**
-   * Options for showing a prompt if the arg is invalid or missing.
-   */
-  promptOptions?: PromptOptions | PromptOptionsFunction
-  /**
-   * A function to validate the supplied value of the arg.
-   */
-  validate?: (arg: GeneratorArgValue, args: GeneratorArgs) => boolean | ArgValidationObject
 }

--- a/src/types/GeneratorConfig.ts
+++ b/src/types/GeneratorConfig.ts
@@ -1,4 +1,4 @@
-import { GeneratorArgConfigEntry } from './GeneratorArg'
+import { GeneratorArgConfigEntry, GeneratorArgConfigEntryFunction } from './GeneratorArg'
 import { GeneratorHooks } from './GeneratorHooks'
 
 export interface GeneratorConfig {
@@ -13,7 +13,7 @@ export interface GeneratorConfig {
   /**
    * List of generator arguments required of the user.
    */
-  args?: GeneratorArgConfigEntry[]
+  args?: (GeneratorArgConfigEntry | GeneratorArgConfigEntryFunction)[]
   /**
    * Used for hooking into the generator lifecycle.
    */

--- a/src/types/GeneratorPromptOptions.ts
+++ b/src/types/GeneratorPromptOptions.ts
@@ -1,0 +1,23 @@
+export type PromptOptions = PromptOptionsInput | PromptOptionsConfirm | PromptOptionsSelect | PromptOptionsMultiSelect
+
+interface PromptOptionsInput {
+  type: 'input'
+  message: string
+}
+
+interface PromptOptionsConfirm {
+  type: 'confirm'
+  message: string
+}
+
+interface PromptOptionsSelect {
+  type: 'select'
+  message: string
+  choices: string[]
+}
+
+interface PromptOptionsMultiSelect {
+  type: 'multi-select'
+  message: string
+  choices: string[]
+}


### PR DESCRIPTION
This changes up the config schema, so the old syntax is now no longer valid. You no longer send prompt options directly to `enquirer`, and you now instead use a more narrowly defined set of prompt types. In the future I'd like to use this to create a much better CLI experience, and I already have a general idea of what that looks like.

**Example before**
```javascript
{
  ...
  args: [
    {
      name: 'example',
      promptOptions: (args) => ({
        type: 'autocomplete',
        choices: generateChoices(),
      }),
      validate: (arg) => generateChoices().includes(arg),
    },
  ],
}
```

**Example after (same result)**
```javascript
{
  ...
  args: [
    (args) => {
      const choices = generateChoices() //
      return  {
        name: 'example',
        prompt: {
          type: 'select',
          choices,
        },
        validate: (arg) => choices.includes(arg),
      }
    },
  ],
}
```