### PR TITLE
Add support for a dedicated ".kig" file extension

### DIFF
--- a/src/modules/jobsGenerator/00-discoverTemplates.ts
+++ b/src/modules/jobsGenerator/00-discoverTemplates.ts
@@ -14,7 +14,7 @@ export function discoverTemplates(generatorLocation: string) {
 
       if (fs.lstatSync(contentPath).isDirectory()) {
         templateFiles = templateFiles.concat(scan(contentPath))
-      } else if (contentName.endsWith('.t.ejs')) {
+      } else if (contentName.endsWith('.t.ejs') || contentName.endsWith('.kig')) {
         templateFiles = templateFiles.concat(contentPath)
       }
     }


### PR DESCRIPTION
The discover module now searches for moth ".t.ejs" and ".kig" file extensions. This allows projects with ejs file formatters (like prettier) that assume ejs is used in an HTML context, to now not add the templates files to the formatters ignore list.